### PR TITLE
Fix arch buildtime detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN set -x \
         openssl \
         nano \
         ffmpeg \
+        file \
         unzip \
         bash \
         curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,11 +41,13 @@ RUN set -x \
 # all supported architectures look at "assets" on
 # https://github.com/just-containers/s6-overlay/releases
 RUN /bin/bash -c 'set -ex && \
-    ARCH="$(uname -m)" && \
+    ARCH="$(apk --print-arch)" && \
     case "${ARCH##*-}" in \
         x86_64) S6_PLATFORM="amd64" ;; \
         armv7l) S6_PLATFORM="armhf" ;; \
+	armv7) S6_PLATFORM="armhf" ;; \
         armv6) S6_PLATFORM="armhf" ;; \
+	armhf) S6_PLATFORM="armhf" ;; \
         arm) S6_PLATFORM="arm" ;; \
         aarch64) S6_PLATFORM="aarch64" ;;\
         i386) S6_PLATFORM="x86" ;;\

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -17,6 +17,7 @@ RUN set -x \
         openssl \
         nano \
         ffmpeg \
+        file \
         unzip \
         bash \
         curl \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,95 @@
+# contains qemu-*-static for cross-compilation
+FROM multiarch/qemu-user-static as qemu
+
+FROM arm64v8/nginx:mainline-alpine
+MAINTAINER Christian Haschek <office@haschek-solutions.com>
+
+ENV S6_VERSION v1.22.1.0
+
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
+
+# Add PHP 7
+RUN set -x \
+    && apk upgrade -U \
+    && apk --update \
+#   --repository=http://dl-4.alpinelinux.org/alpine/edge/testing \
+        add \
+        openssl \
+        nano \
+        ffmpeg \
+        unzip \
+        bash \
+        curl \
+        php7 \
+        php7-pdo \
+        php7-exif \
+        php7-mcrypt \
+        php7-curl \
+        php7-gd \
+        php7-json \
+        php7-fpm \
+        php7-openssl \
+        php7-ctype \
+        php7-opcache \
+        php7-mbstring \
+        php7-session \
+        php7-fileinfo \
+        php7-pcntl \
+    && rm -rf /var/cache/apk/*
+
+# s6 overlay
+# all supported architectures look at "assets" on
+# https://github.com/just-containers/s6-overlay/releases
+RUN /bin/bash -c 'set -ex && \
+    ARCH="$(uname -m)" && \
+    case "${ARCH##*-}" in \
+        x86_64) S6_PLATFORM="amd64" ;; \
+        armv7l) S6_PLATFORM="armhf" ;; \
+        armv6) S6_PLATFORM="armhf" ;; \
+        arm) S6_PLATFORM="arm" ;; \
+        aarch64) S6_PLATFORM="aarch64" ;;\
+        i386) S6_PLATFORM="x86" ;;\
+        *) echo >&2 "unsupported architecture: ${ARCH}"; exit 1 ;; \
+    esac; \
+    curl -L -s https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-${S6_PLATFORM}.tar.gz \
+  | tar xvzf - -C / '
+
+
+COPY /rootfs /
+
+RUN set -x \
+    && rm /usr/bin/php \
+    && ln -s /etc/php7 /etc/php \
+    && ln -s /usr/bin/php7 /usr/bin/php \
+    && ln -s /usr/sbin/php-fpm7 /usr/bin/php-fpm \
+    && ln -s /usr/lib/php7 /usr/lib/php \
+#    && ln -s /dev/stdout /var/log/nginx/access.log \
+#    && ln -s /dev/stderr /var/log/nginx/error.log \
+    && mkdir -p /var/log/php-fpm \
+    && ln -s /dev/stderr /var/log/php-fpm/fpm-error.log
+
+# Enable default sessions
+RUN set -x \
+    && mkdir -p /var/lib/php7/sessions \
+    && chown nginx:nginx /var/lib/php7/sessions
+
+# ADD SOURCE
+RUN set -x \
+    && mkdir -p /usr/share/nginx/html
+
+WORKDIR /usr/share/nginx/html
+
+RUN set -x \
+    && curl --silent --remote-name https://codeload.github.com/HaschekSolutions/pictshare/zip/master \
+    && unzip -q master \
+    && mv pictshare-master/* . \
+    && rm -r master pictshare-master \
+    && mv inc/example.config.inc.php inc/config.inc.php \
+    && chown -R nginx:nginx /usr/share/nginx/html \
+    && chmod +x bin/ffmpeg
+
+VOLUME /usr/share/nginx/html/data
+
+EXPOSE 80
+
+ENTRYPOINT ["bash", "/pictshare.sh"]

--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -17,6 +17,7 @@ RUN set -x \
         openssl \
         nano \
         ffmpeg \
+        file \
         unzip \
         bash \
         curl \

--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -1,0 +1,95 @@
+# contains qemu-*-static for cross-compilation
+FROM multiarch/qemu-user-static as qemu
+
+FROM arm32v6/nginx:mainline-alpine
+MAINTAINER Christian Haschek <office@haschek-solutions.com>
+
+ENV S6_VERSION v1.22.1.0
+
+COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin
+
+# Add PHP 7
+RUN set -x \
+    && apk upgrade -U \
+    && apk --update \
+#   --repository=http://dl-4.alpinelinux.org/alpine/edge/testing \
+        add \
+        openssl \
+        nano \
+        ffmpeg \
+        unzip \
+        bash \
+        curl \
+        php7 \
+        php7-pdo \
+        php7-exif \
+        php7-mcrypt \
+        php7-curl \
+        php7-gd \
+        php7-json \
+        php7-fpm \
+        php7-openssl \
+        php7-ctype \
+        php7-opcache \
+        php7-mbstring \
+        php7-session \
+        php7-fileinfo \
+        php7-pcntl \
+    && rm -rf /var/cache/apk/*
+
+# s6 overlay
+# all supported architectures look at "assets" on
+# https://github.com/just-containers/s6-overlay/releases
+RUN /bin/bash -c 'set -ex && \
+    ARCH="$(uname -m)" && \
+    case "${ARCH##*-}" in \
+        x86_64) S6_PLATFORM="amd64" ;; \
+        armv7l) S6_PLATFORM="armhf" ;; \
+        armv6) S6_PLATFORM="armhf" ;; \
+        arm) S6_PLATFORM="arm" ;; \
+        aarch64) S6_PLATFORM="aarch64" ;;\
+        i386) S6_PLATFORM="x86" ;;\
+        *) echo >&2 "unsupported architecture: ${ARCH}"; exit 1 ;; \
+    esac; \
+    curl -L -s https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-${S6_PLATFORM}.tar.gz \
+  | tar xvzf - -C / '
+
+
+COPY /rootfs /
+
+RUN set -x \
+    && rm /usr/bin/php \
+    && ln -s /etc/php7 /etc/php \
+    && ln -s /usr/bin/php7 /usr/bin/php \
+    && ln -s /usr/sbin/php-fpm7 /usr/bin/php-fpm \
+    && ln -s /usr/lib/php7 /usr/lib/php \
+#    && ln -s /dev/stdout /var/log/nginx/access.log \
+#    && ln -s /dev/stderr /var/log/nginx/error.log \
+    && mkdir -p /var/log/php-fpm \
+    && ln -s /dev/stderr /var/log/php-fpm/fpm-error.log
+
+# Enable default sessions
+RUN set -x \
+    && mkdir -p /var/lib/php7/sessions \
+    && chown nginx:nginx /var/lib/php7/sessions
+
+# ADD SOURCE
+RUN set -x \
+    && mkdir -p /usr/share/nginx/html
+
+WORKDIR /usr/share/nginx/html
+
+RUN set -x \
+    && curl --silent --remote-name https://codeload.github.com/HaschekSolutions/pictshare/zip/master \
+    && unzip -q master \
+    && mv pictshare-master/* . \
+    && rm -r master pictshare-master \
+    && mv inc/example.config.inc.php inc/config.inc.php \
+    && chown -R nginx:nginx /usr/share/nginx/html \
+    && chmod +x bin/ffmpeg
+
+VOLUME /usr/share/nginx/html/data
+
+EXPOSE 80
+
+ENTRYPOINT ["bash", "/pictshare.sh"]

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Register qemu-*-static for all supported processors except the
+# current one, but also remove all registered binfmt_misc before
+docker run --rm --privileged multiarch/qemu-user-static:register --reset

--- a/rootfs/pictshare.sh
+++ b/rootfs/pictshare.sh
@@ -23,7 +23,10 @@ _update() {
 }
 
 _filePermissions() {
+    touch /usr/share/nginx/html/data/sha1.csv
     chown -R nginx:nginx /usr/share/nginx/html
+    chmod -R 777 /usr/share/nginx/html/data
+    chmod -R 777 /usr/share/nginx/html/tmp
 }
 
 _buildConfig() {
@@ -60,6 +63,8 @@ _main() {
     fi
 
     _buildConfig > inc/config.inc.php
+
+    _filePermissions
 
     echo '[i] Done! Starting nginx'
 


### PR DESCRIPTION
uname reports aarch64 platform instead armv7 or armhf if runs with buildkit on aarch64 with armv7 target
like `docker buildx build --platform linux/arm64,linux/amd64,linux/arm/v7 -t shtripok/pictshare  --push  .`