### PR TITLE
detect target architecure with more correct way

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,11 +41,13 @@ RUN set -x \
 # all supported architectures look at "assets" on
 # https://github.com/just-containers/s6-overlay/releases
 RUN /bin/bash -c 'set -ex && \
-    ARCH="$(uname -m)" && \
+    ARCH="$(apk --print-arch)" && \
     case "${ARCH##*-}" in \
         x86_64) S6_PLATFORM="amd64" ;; \
         armv7l) S6_PLATFORM="armhf" ;; \
+	armv7) S6_PLATFORM="armhf" ;; \
         armv6) S6_PLATFORM="armhf" ;; \
+	armhf) S6_PLATFORM="armhf" ;; \
         arm) S6_PLATFORM="arm" ;; \
         aarch64) S6_PLATFORM="aarch64" ;;\
         i386) S6_PLATFORM="x86" ;;\


### PR DESCRIPTION
uname reports aarch64 platform instead armv7 or armhf if runs with buildkit on aarch64 with armv7 target
like `docker buildx build --platform linux/arm64,linux/amd64,linux/arm/v7 -t shtripok/pictshare  --push  .`